### PR TITLE
Create home-markdown-usage.md

### DIFF
--- a/home-markdown-usage.md
+++ b/home-markdown-usage.md
@@ -1,0 +1,8 @@
+This card renders markdown hosted in github. You can render your own content using the following props:
+
+- **title**: The card title (default: 'Usage')
+- **repo**: The name of the repo containing the markdown (default: 'demo-data')
+- **owner**: The github github org in the above repo is located (default: 'RoadieHQ')
+- **path**: The path to the markdown file to render in the target repo (default: 'home-markdown-usage.md')
+
+Admin users can configure this card following [these instructions](https://roadie.io/docs/getting-started/updating-the-ui/#adding-props)

--- a/homepage-markdown-card-usage.md
+++ b/homepage-markdown-card-usage.md
@@ -3,6 +3,6 @@ This card renders markdown hosted in github. You can render your own content usi
 - **title**: The card title (default: 'Usage')
 - **repo**: The name of the repo containing the markdown (default: 'demo-data')
 - **owner**: The github github org in the above repo is located (default: 'RoadieHQ')
-- **path**: The path to the markdown file to render in the target repo (default: 'home-markdown-usage.md')
+- **path**: The path to the markdown file to render in the target repo (default: 'homepage-markdown-card-usage.md')
 
 Admin users can configure this card following [these instructions](https://roadie.io/docs/getting-started/updating-the-ui/#adding-props)


### PR DESCRIPTION
Adds some default content for the home page markdown card. Putting it here rather than with the plugin as this is default for the roadie platform only as we refer to our internal docs to explain how to add props via the UI (this is up for debate though).